### PR TITLE
Bugfix: Moving While in Combat

### DIFF
--- a/Implementation/GenericRPG/FrmArena.Designer.cs
+++ b/Implementation/GenericRPG/FrmArena.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GenericRPG {
+﻿using System;
+
+namespace GenericRPG {
   partial class FrmArena {
     /// <summary>
     /// Required designer variable.
@@ -15,6 +17,8 @@
       }
       base.Dispose(disposing);
     }
+
+    public FrmMap parentMap;
 
     #region Windows Form Designer generated code
 
@@ -508,8 +512,19 @@
 
     }
 
-    #endregion
-    private System.Windows.Forms.Label lblPlayerHealth;
+        public void parentForm(FrmMap map)
+        {
+            parentMap = map;
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            parentMap.inCombat = false;
+            base.OnClosed(e);
+        }
+
+        #endregion
+        private System.Windows.Forms.Label lblPlayerHealth;
     private System.Windows.Forms.PictureBox picCharacter;
     private System.Windows.Forms.Label lblPlayerStr;
     private System.Windows.Forms.Label lblPlayerDef;

--- a/Implementation/GenericRPG/FrmMap.cs
+++ b/Implementation/GenericRPG/FrmMap.cs
@@ -9,6 +9,7 @@ namespace GenericRPG {
     private Character character;
     private Map map;
     private Game game;
+    public bool inCombat = false;
 
     public FrmMap() {
       InitializeComponent();
@@ -42,10 +43,12 @@ namespace GenericRPG {
           dir = MoveDir.DOWN;
           break;
       }
-      if (dir != MoveDir.NO_MOVE) {
+      if (dir != MoveDir.NO_MOVE && inCombat == false) {
         character.Move(dir);
         if (game.State == GameState.FIGHTING) {
           FrmArena frmArena = new FrmArena();
+          frmArena.parentForm(this);
+          inCombat = true;
           frmArena.Show();
         }
       }


### PR DESCRIPTION
While in combat it was possible to move around the map and start other encounters, all with the same health, then fight them all at once.

Changes: Added a variable to FrmMap that indicated whether or not FrmArena was opened. If it was, then the player could not move. Once the window was closed the player could move again.

Modified:
-FrmMap.cs
-FrmaArena.cs
